### PR TITLE
DevDependencies & npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,12 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
+    "typescript": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "dev": true
+    },
     "ua-parser-js": {
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "jinto-website",
-  "version": "0.1.0",
+  "name": "react-motion-waypoint",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.5.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.5.tgz",
       "integrity": "sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -21,6 +23,7 @@
       "version": "16.4.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.11.tgz",
       "integrity": "sha512-1DQnmwO8u8N3ucvRX2ZLDEjQ2VctkAvL/rpbm2ev4uaZA0z4ysU+I0tk+K8ZLblC6p7MCgFyF+cQlSNIPUHzeQ==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -30,6 +33,7 @@
       "version": "16.0.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.7.tgz",
       "integrity": "sha512-vaq4vMaJOaNgFff1t3LnHYr6vRa09vRspMkmLdXtFZmO1fwDI2snP+dpOkwrtlU8UC8qsqemCu4RmVM2OLq/fA==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/react": "*"
@@ -39,6 +43,7 @@
       "version": "0.0.27",
       "resolved": "https://registry.npmjs.org/@types/react-motion/-/react-motion-0.0.27.tgz",
       "integrity": "sha512-IvUTegF4hUWKEqVp3/hPYNJ6cjWfK2c48oNK4KJGAyUFpNqonTCoOL0FLrE/ITPmn1D0bS4D2gMKJyB0L+MtOw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -56,7 +61,8 @@
     "csstype": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.6.tgz",
-      "integrity": "sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ=="
+      "integrity": "sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ==",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   },
   "author": "Aloïs Deniel",
   "dependencies": {
-    "@types/react": "^16.4.9",
-    "@types/react-dom": "^16.0.7",
-    "@types/react-motion": "0.0.27",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-motion": "^0.5.2"
@@ -20,5 +17,10 @@
   "files": [
     "lib",
     "src"
-  ]
+  ],
+  "devDependencies": {
+    "@types/react": "^16.4.11",
+    "@types/react-dom": "^16.0.7",
+    "@types/react-motion": "0.0.27"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && cd docs && webpack"
+    "build": "tsc && cd docs && npm run build"
   },
   "author": "Aloïs Deniel",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc --sourcemap && cd docs && npm run build"
+    "build": "tsc --sourcemap && cd docs && npm run build",
+    "build-release": "tsc"
   },
   "author": "Aloïs Deniel",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && cd docs && npm run build"
+    "build": "tsc --sourcemap && cd docs && npm run build"
   },
   "author": "Aloïs Deniel",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
-    "@types/react-motion": "0.0.27"
+    "@types/react-motion": "0.0.27",
+    "typescript": "^3.0.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
     "compilerOptions": {
         "outDir": "./lib/",
-        "sourceMap": true,
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "lib": [ "dom", "es6" ],
         "declaration": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "./lib/",
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es6",
+        "target": "es5",
         "jsx": "react",
         "lib": [ "dom", "es6" ],
         "declaration": true


### PR DESCRIPTION
This PR solves a couple of problems on dependencies and npm scripts:
- All @types packages need to be dev dependencies.
- Add TypeScript as a dev dependencies. It ensures that external contributors and CI processes use the same version of the compiler.
- Fix npm build script. An error occured when Webpack is missing locally. Lib and Docs example doesn't have the same npm context that's why npm try to find Webpack in the global packages. To fix this issue -> call directly the npm build script of the Docs example :)
- The npm package contains the source map, it's not great for production. To fix this issue, Source mapping is now by default to false. The build script use the sourcemap flag to generate sourcemap in debug and a new build-release script was added to generate the library without source mapping (usefull for CI).


All those changes don't have any impacts on the current source code that was generated in the lib folder.